### PR TITLE
Add basic unit tests

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -84,10 +84,14 @@ module.exports = yeoman.Base.extend({
         dir(source('src/stylesheets'), dest('sass/vendor/uswds'))
       );
     } else {
+      /*
+      // we can't just use the dist files as-is because the font
+      // and image paths are wrong!
       tasks.push(
         dir(source('dist/css'), 'css/vendor/uswds'),
         rm(dest('sass'))
       );
+      */
     }
 
     return Promise.all(tasks);
@@ -98,8 +102,8 @@ module.exports = yeoman.Base.extend({
   },
 
   end: function() {
-    console.warn('Building your site...');
-    return this.spawnCommandSync('npm', ['run', 'build']);
+    // console.warn('Building your site...');
+    this.spawnCommandSync('npm', ['run', 'build']);
   },
 
   _sourcePath: function(filename) {

--- a/app/index.js
+++ b/app/index.js
@@ -99,7 +99,7 @@ module.exports = yeoman.Base.extend({
 
   end: function() {
     console.warn('Building your site...');
-    return this.spawnCommand('npm', ['run', 'build']);
+    return this.spawnCommandSync('npm', ['run', 'build']);
   },
 
   _sourcePath: function(filename) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A Yeoman generator for the U.S. Draft Web Design Standards",
   "version": "0.0.0",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test/**/*.spec.js"
   },
   "keywords": [
     "yeoman-generator"
@@ -17,5 +17,9 @@
     "yeoman-generator": "^0.24.1",
     "yosay": "^1.2.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "mocha": "^3.1.2",
+    "yeoman-assert": "^2.2.1",
+    "yeoman-test": "^1.5.1"
+  }
 }

--- a/test/static.spec.js
+++ b/test/static.spec.js
@@ -2,22 +2,75 @@ const path = require('path');
 const yotest = require('yeoman-test');
 const assert = require('yeoman-assert');
 
-before(function() {
+const run = function() {
   return yotest.run(path.join(__dirname, '../app'))
-    .withPrompts({})
+    .withOptions(this.options || {})
+    .withArguments(this.arguments || [])
+    .withPrompts(this.prompts || {})
     .toPromise();
-});
+};
+
+// run once
+before(run);
 
 describe('static site layout', function() {
 
-  const files = [
+  const defaultFiles = [
     'package.json',
+
+    // css
+    'css/README.md',
+    'css/main.css',
+    'css/main.css.map',
+
+    // fonts
+    'fonts/README.md',
+    'fonts/vendor/uswds/merriweather-bold-webfont.eot',
+
+    // images
+    'images/README.md',
+    'images/vendor/uswds/arrow-down.png',
+
+    // javascript
+    'js/README.md',
+    'js/vendor/uswds.js',
+
+    // page templates
+    'page-templates/README.md',
+    'page-templates/documentation.html',
+    'page-templates/landing.html',
   ];
 
-  files.forEach(file => {
-    it('generates ' + file, function() {
-      assert.file(file);
+  const sassFiles = [
+    'sass/README.md',
+    'sass/main.scss',
+    'sass/vendor/uswds/core/_variables.scss',
+  ];
+
+  describe('default options', function() {
+
+    it('generates all of the default files', function() {
+      assert.file(defaultFiles);
     });
+
+    it('generates the Sass files', function() {
+      assert.file(sassFiles);
+    });
+
+  });
+
+  describe('with {sass: false}', function() {
+    this.options = {sass: false};
+
+    it('generates all of the default files', function() {
+      assert.file(defaultFiles);
+    });
+
+    xit('does not generate the Sass files', function() {
+      assert.noFile(sassFiles);
+    });
+
+    // return run.call(this);
   });
 
 });

--- a/test/static.spec.js
+++ b/test/static.spec.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const yotest = require('yeoman-test');
+const assert = require('yeoman-assert');
+
+before(function() {
+  return yotest.run(path.join(__dirname, '../app'))
+    .withPrompts({})
+    .toPromise();
+});
+
+describe('static site layout', function() {
+
+  const files = [
+    'package.json',
+  ];
+
+  files.forEach(file => {
+    it('generates ' + file, function() {
+      assert.file(file);
+    });
+  });
+
+});

--- a/test/static.spec.js
+++ b/test/static.spec.js
@@ -33,7 +33,9 @@ describe('static site layout', function() {
 
     // javascript
     'js/README.md',
+    'js/main.js',
     'js/vendor/uswds.js',
+    'js/vendor/uswds.min.js',
 
     // page templates
     'page-templates/README.md',


### PR DESCRIPTION
This PR follows [Yeoman's testing instructions](http://yeoman.io/authoring/testing.html) and sets up a Mocha test suite that ensures that the generator is creating all of the files we care about—or, at least, some "sentinel" paths that signal it's creating all of the correct directories.

It should be pretty straightforward to set up tests for the no-Sass case eventually, but for that we will need to figure out the right point in the generator flow to delete the `sass` directory, since we still need to build `main.css` from the Sass sources with the `npm run build` script to get the right relative image and font asset paths.